### PR TITLE
Do not publish analysis of trello board anymore

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,8 @@ jobs:
         run: |
           jupyter nbconvert src/Community-Statistik-inkl-Aktivierungsrate.ipynb --execute --to html
           jupyter nbconvert src/Community-Statistik+KPI-Uebersicht.ipynb --execute --to html
-          jupyter nbconvert src/analysis-of-our-trello-board.ipynb --execute --to html
         env:
           JUPYTER_CONFIG_DIR: ./jupyter
-          TRELLO_API_KEY: ${{ secrets.TRELLO_API_KEY }}
-          TRELLO_TOKEN: ${{ secrets.TRELLO_TOKEN }}
 
       - name: Prepare public folder
         run: |


### PR DESCRIPTION
We are not using it anymore.
And it's also running into [errors](https://github.com/serlo/evaluations/actions/runs/8735215557).